### PR TITLE
Naming threads of the main components

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 /// Start the controller, spawning a thread and returning the join handle.
 pub fn start(query_link: (Sender<Request>, Receiver<Response>)) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
+    thread::Builder::new().name("kairoi/ctrl".to_string()).spawn(move || {
         let mut clients = HashMap::new();
         let mut identifier: u128 = 0;
 
@@ -84,5 +84,5 @@ pub fn start(query_link: (Sender<Request>, Receiver<Response>)) -> thread::JoinH
                 None => {},
             };
         }
-    })
+    }).unwrap()
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -38,7 +38,7 @@ impl Database {
         query_link: (Sender<QueryResponse>, Receiver<QueryRequest>),
         execution_link: (ExecutionSender, ExecutionReceiver),
     ) -> thread::JoinHandle<()> {
-        thread::spawn(move || {
+        thread::Builder::new().name("kairoi/db".to_string()).spawn(move || {
             let mut database = Database {
                 storage: Storage::new(),
                 execution_client: ExecutionClient::new(execution_link),
@@ -65,7 +65,7 @@ impl Database {
                 database.trigger_execution();
                 database.handle_results();
             });
-        })
+        }).unwrap()
     }
 
     /// Check every waiting job, and trigger the execution when needed.

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -35,11 +35,11 @@ pub struct Processor {}
 impl Processor {
     /// Start the processor, spawning a thread and returning the join handle.
     pub fn start((sender, receiver): (Sender, Receiver)) -> thread::JoinHandle<()> {
-        thread::spawn(move || {
+        thread::Builder::new().name("kairoi/proc".to_string()).spawn(move || {
             let mut dispatcher = Dispatcher::new(sender, receiver);
 
             dispatcher.run()
-        })
+        }).unwrap()
     }
 }
 


### PR DESCRIPTION
When inspecting thread usage for performance issues, there is no way to know which thread run which component.

It adds a name on each of these 3 threads. The controller thread is named `kairoi/ctrl`, the database thread `kairoi/db`, and the processor thread `kairoi/proc`. In a tool like `htop`, the `kairoi/` prefix allows to see all threads when searching on the keyword `kairoi`.

It should be noted that thread names are limited to 15 readable characters on Linux, and that's why each component name is shortened.