### PR TITLE
Prevent jobs from being locked in the triggered state

### DIFF
--- a/src/database/storage/job.rs
+++ b/src/database/storage/job.rs
@@ -75,7 +75,7 @@ impl Storage
 
     /// Retrieve all jobs to be executed at the given current_datetime (included). Only retrieve
     /// jobs in the Planned status.
-    pub fn get_to_execute(&self, current_datetime: &DateTime<Utc>) -> Vec<&Job> {
+    pub fn get_to_execute(&self, current_datetime: &DateTime<Utc>) -> Vec<Job> {
         // Retrieve the position of the first element having an execution time beyond the current
         // time, then return all the previous elements of the to_execute vector.
         match self.to_execute.iter().position(|element| element.get_execution() > current_datetime) {
@@ -83,7 +83,7 @@ impl Storage
                 let mut result = Vec::with_capacity(position);
 
                 for job in &self.to_execute[0..position] {
-                    result.push(job);
+                    result.push(job.clone());
                 };
 
                 result
@@ -92,7 +92,7 @@ impl Storage
                 let mut result = Vec::with_capacity(self.to_execute.len());
 
                 for job in &self.to_execute[..] {
-                    result.push(job);
+                    result.push(job.clone());
                 };
 
                 result


### PR DESCRIPTION
It resolves https://github.com/emerick42/kairoi/issues/6.

It allows the operation of marking jobs as `executed` or `failed` to be retried later, in case an error occurs while writing to the persistent storage. Jobs are left in the `triggered` state as long as the operation fails. If the software is restarted while a job is in the `triggered` state, the job is automatically re-triggered (causing a potential duplicated job execution) during boot. The maximum lifetime (or timeout) of a job thus become the lifetime of the Kairoi server.

A side-effect of the retry system is that the memory taken by the database is growing linearly with the number of job state modifications to be retried. If the persistent storage stay unavailable for a long time for any reason, the memory and the processor used by the server may increase a lot.

A mechanism should be added in the future to prevent the database component from going wild (error log spam, system resource usage increase, etc.) in case of extended persistent storage unavailability.