### PR TITLE
Make the software configurable through a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+/logfile
+/logfile.compressed
+/configuration.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.2",
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,9 +523,12 @@ version = "0.1.0"
 dependencies = [
  "amiquip",
  "chrono",
+ "config",
  "crossbeam-channel 0.5.1",
  "log",
  "nom 6.2.1",
+ "serde",
+ "serde_derive",
  "simple_logger",
  "uuid",
 ]
@@ -704,6 +719,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "nom"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
@@ -774,9 +800,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",
@@ -826,7 +852,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2 1.0.29",
  "quote 1.0.9",
- "syn 1.0.76",
+ "syn 1.0.77",
 ]
 
 [[package]]
@@ -842,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1061,7 +1087,7 @@ checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.9",
- "syn 1.0.76",
+ "syn 1.0.77",
 ]
 
 [[package]]
@@ -1147,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2 1.0.29",
  "quote 1.0.9",
@@ -1188,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ nom = { version = "6.2.1" }
 simple_logger = { version = "1.6.0" }
 uuid = { version = "0.8.1", default-features = false, features = ["v4"] }
 crossbeam-channel = { version = "0.5.1" }
+config = { version = "0.11.0", default-features = false, features = ["toml"] }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_derive = { version = "1.0.130" }
 # Optional dependencies.
 amiquip = { version = "0.3.3", optional = true }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,26 @@
+# Kairoi Server Configuration
+
+## Quick Words
+
+Kairoi servers can be configured at runtime using a [TOML](https://toml.io/en/) configuration file. The configuration file must be located at `configuration.toml`, relative to the executable directory. Since every option has a default value, a Kairoi server can be started without any configuration file.
+
+Here is an example of configuration file with all default options explicitly set:
+
+```toml
+[log]
+level = "info" # One of "trace", "debug", "info", "warn", "error" or "off".
+```
+
+## Usage
+
+### Log
+
+The `log` table contains all configuration options related to Kairoi's logging. Currently, logging can only be configured to filter messages based on their log level.
+
+#### Level
+
+`log.level`: `String` (default: `info`)
+
+This option can have a value being either `trace`, `debug`, `info`, `warn`, `error` or `off`. The `trace` log level will output every log messages, and `off` log level will output no message at all.
+
+## Internals

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,12 @@ Kairoi is a **Time-based Job Scheduler**. It works as a server allowing its clie
 
 Once the job execution time is past, Kairoi automatically triggers a job execution on a matching configured runner (read more about runners in the [Kairoi Runners documentation](runners.md)).
 
+### Summary
+
+- [Kairoi Client Protocol Documentation](client-protocol.md)
+- [Kairoi Runners Documentation](runners.md)
+- [Kairoi Server Configuration Reference](configuration.md)
+
 ## Usage
 
 ## Internals

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,0 +1,66 @@
+//! Kairoi's main configuration, loading the user's runtime configuration.
+//!
+//! The user's runtime configuration is loaded from the file `configuration.toml`, relative to the
+//! executable directory. Every configuration option has a default value, allowing to start the
+//! server without a configuration file.
+
+use config::Config;
+use config::ConfigError;
+use config::File;
+use config::FileFormat;
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+impl Default for LogLevel {
+    fn default() -> Self {
+        LogLevel::Info
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Log {
+    #[serde(default)]
+    pub level: LogLevel,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Configuration {
+    #[serde(default)]
+    pub log: Log,
+}
+
+impl Configuration {
+    /// Load the configuration from the `configuration.toml` file. It returns a properly
+    /// instantiated configuration tree in case of success, or a message describing the error in
+    /// case of error.
+    pub fn new() -> Result<Self, String> {
+        match Self::load() {
+            Ok(configuration) => Ok(configuration),
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    fn load() -> Result<Self, ConfigError> {
+        let mut configuration = Config::default();
+
+        let file =
+            File::with_name("configuration.toml")
+            .format(FileFormat::Toml)
+            .required(false)
+        ;
+        configuration.merge(file)?;
+
+        configuration.try_into()
+    }
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,35 @@
+//! Kairoi's global logging system.
+//!
+//! Kairoi uses the standard [log](https://docs.rs/log/0.4.14/log/) crate, with the
+//! [simple_logger](https://docs.rs/simple_logger/1.13.0/simple_logger/) implementation, to enable
+//! logging in the entire application.
+//!
+//! This module only provides an encapsulation of their initialization.
+
+use log::Level as LogLevel;
+
+pub enum Level {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+pub struct Logger {}
+
+impl Logger {
+    /// Initialize the global logger with the given level. In case of failure, this method panicks.
+    /// It must only be used once, since all subsequent calls will result in a failure.
+    pub fn initialize(level: Level) {
+        match level {
+            Level::Off => {},
+            Level::Error => simple_logger::init_with_level(LogLevel::Error).unwrap(),
+            Level::Warn => simple_logger::init_with_level(LogLevel::Warn).unwrap(),
+            Level::Info => simple_logger::init_with_level(LogLevel::Info).unwrap(),
+            Level::Debug => simple_logger::init_with_level(LogLevel::Debug).unwrap(),
+            Level::Trace => simple_logger::init_with_level(LogLevel::Trace).unwrap(),
+        };
+    }
+}


### PR DESCRIPTION
It resolves https://github.com/emerick42/kairoi/issues/11.

It loads an optional `configuration.toml` file while booting, allowing Kairoi's users to define a custom runtime configuration. All configuration options have a default value, allowing the server to be started without writing an explicit configuration file. The configuration file uses the TOML format (a [TOML reference can be found here](https://toml.io/en/)).

Currently, only the `log.level` option is configurable. It allows to completely disable all logging, or to filter logs having a severity above or equal the configured value. For example, the configuration `log.level = "debug"` will display all log messages, except the ones with the `trace` level. The `trace`, `debug`, `info` (default), `warn`, `error` and `off` levels are available (this list is in order of severity).

This `log.level` configuration is only an example and a proof of work, the core of this PR being to create the configuration system. More configuration options should be added in the future.