### PR TITLE
Feature / Controller Listen Global

### DIFF
--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -17,7 +17,7 @@ pub fn start(query_link: (Sender<Request>, Receiver<Response>)) -> thread::JoinH
         let mut clients = HashMap::new();
         let mut identifier: u128 = 0;
 
-        let bind = String::from("127.0.0.1:5678");
+        let bind = String::from("0.0.0.0:5678");
         let server = TcpListener::bind(&bind).unwrap();
         server.set_nonblocking(true).unwrap();
 


### PR DESCRIPTION
Currently, the controller is listening on connections coming from clients addressed as `127.0.0.1`. This is more secure, since it prevents unknown clients from connecting. But because there is no configuration option for this listen scheme yet, it's blocking the server from being usable in some environments (with a Dockerized client, for example).

For now, we are setting the controller to listen on connections from any client (`0.0.0.0`).

When implementing the configuration option, the default value should be set back to `127.0.0.1:5678`.