### PR TITLE
Feature / Configuration Controller Listen

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,9 @@ Here is an example of configuration file with all default options explicitly set
 ```toml
 [log]
 level = "info" # One of "trace", "debug", "info", "warn", "error" or "off".
+
+[controller]
+listen = "127.0.0.1:5678" # You can use "0.0.0.0:5678" to accept connections from any client.
 ```
 
 ## Usage
@@ -22,5 +25,15 @@ The `log` table contains all configuration options related to Kairoi's logging. 
 `log.level`: `String` (default: `info`)
 
 This option can have a value being either `trace`, `debug`, `info`, `warn`, `error` or `off`. The `trace` log level will output every log messages, and `off` log level will output no message at all.
+
+### Controller
+
+The `controller` table contains all configuration options related to Kairoi's controller, the component responsible for handling clients.
+
+#### Listen
+
+`controller.listen`: `String` (default: `127.0.0.1:5678`)
+
+This option configures the address on which the controller listens to clients. It can be used to restrict access to certain clients. By default, it uses the most restrictive `127.0.0.1:5678`, accepting only connections from localhost clients. It can be set to `0.0.0.0:5678` to accept any client. The port can also be set to `127.0.0.1:0` to request that the OS assigns a port to the listener (although currently, the assigned port is only retrievable from `info` logs in a human readable format).
 
 ## Internals

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -34,10 +34,32 @@ pub struct Log {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct ControllerListen (String);
+impl ToString for ControllerListen {
+    fn to_string(&self) -> String {
+        self.0.clone()
+    }
+}
+impl Default for ControllerListen {
+    fn default() -> Self {
+        Self ("127.0.0.1:5678".to_string())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Controller {
+    #[serde(default)]
+    pub listen: ControllerListen,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Configuration {
     #[serde(default)]
     pub log: Log,
+    #[serde(default)]
+    pub controller: Controller,
 }
 
 impl Configuration {

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -2,7 +2,6 @@ mod client;
 
 use client::Client;
 use crate::query::{Request, Response};
-use log::debug;
 use std::collections::HashMap;
 use std::io;
 use std::net::TcpListener;
@@ -11,78 +10,83 @@ use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-/// Start the controller, spawning a thread and returning the join handle.
-pub fn start(query_link: (Sender<Request>, Receiver<Response>)) -> thread::JoinHandle<()> {
-    thread::Builder::new().name("kairoi/ctrl".to_string()).spawn(move || {
-        let mut clients = HashMap::new();
-        let mut identifier: u128 = 0;
+pub struct Controller {}
 
-        let bind = String::from("0.0.0.0:5678");
-        let server = TcpListener::bind(&bind).unwrap();
-        server.set_nonblocking(true).unwrap();
+impl Controller {
+    /// Start the controller, spawning a thread and returning the join handle. The given listen
+    /// parameter should be a listenable address, including the port (for example
+    /// `127.0.0.1:5678`), otherwise the thread will panic.
+    pub fn start(listen: String, query_link: (Sender<Request>, Receiver<Response>)) -> thread::JoinHandle<()> {
+        thread::Builder::new().name("kairoi/ctrl".to_string()).spawn(move || {
+            let mut clients = HashMap::new();
+            let mut identifier: u128 = 0;
 
-        debug!("Waiting for connections on {}.", bind);
+            let server = TcpListener::bind(&listen).unwrap();
+            server.set_nonblocking(true).unwrap();
 
-        loop {
-            let previous_time = Instant::now();
+            log::info!("Waiting for connections on {}.", &server.local_addr().unwrap());
 
-            // Accept all incoming connections.
             loop {
-                match server.accept() {
-                    Ok(stream) => {
-                        // @TODO: Handle the connection.
-                        let (producer, consumer) = mpsc::channel();
-                        clients.insert(identifier, producer);
-                        Client::spawn(identifier, stream.0, query_link.0.clone(), consumer);
-                        identifier += 1;
+                let previous_time = Instant::now();
+
+                // Accept all incoming connections.
+                loop {
+                    match server.accept() {
+                        Ok(stream) => {
+                            // @TODO: Handle the connection.
+                            let (producer, consumer) = mpsc::channel();
+                            clients.insert(identifier, producer);
+                            Client::spawn(identifier, stream.0, query_link.0.clone(), consumer);
+                            identifier += 1;
+                        },
+                        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                            break;
+                        },
+                        Err(error) => panic!("Encountered IO error: {}", error),
+                    };
+                }
+
+                // Pull all received confirmation messages.
+                loop {
+                    match query_link.1.try_recv() {
+                        Ok(response) => {
+                            // Dispatch the result to the corresponding client.
+                            let client = response.get_request().get_client();
+                            let result = match clients.get_mut(&client) {
+                                Some(producer) => {
+                                    match producer.send(response) {
+                                        Ok(_) => Ok(()),
+                                        Err(_) => {
+                                            log::debug!("Removing client {} (thread ended).", client);
+                                            clients.remove(&client);
+
+                                            Err(())
+                                        },
+                                    }
+                                },
+                                None => Err(()),
+                            };
+                            if let Err(_) = result {
+                                log::debug!("[controller] Unable to notify the client {} for a response (client disconnected).", client);
+                            };
+                        },
+                        Err(error) => match error {
+                            TryRecvError::Empty => break,
+                            TryRecvError::Disconnected => panic!("Query channel disconnected."),
+                        },
+                    }
+                }
+
+                // Put the thread asleep to run at a maximum of 128 time per second.
+                let now = Instant::now();
+                let elapsed_time = now.duration_since(previous_time);
+                match Duration::new(0, 1_000_000_000u32 / 128).checked_sub(elapsed_time) {
+                    Some(sleep_time) => {
+                        thread::sleep(sleep_time);
                     },
-                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                        break;
-                    },
-                    Err(error) => panic!("Encountered IO error: {}", error),
+                    None => {},
                 };
             }
-
-            // Pull all received confirmation messages.
-            loop {
-                match query_link.1.try_recv() {
-                    Ok(response) => {
-                        // Dispatch the result to the corresponding client.
-                        let client = response.get_request().get_client();
-                        let result = match clients.get_mut(&client) {
-                            Some(producer) => {
-                                match producer.send(response) {
-                                    Ok(_) => Ok(()),
-                                    Err(_) => {
-                                        debug!("Removing client {} (thread ended).", client);
-                                        clients.remove(&client);
-
-                                        Err(())
-                                    },
-                                }
-                            },
-                            None => Err(()),
-                        };
-                        if let Err(_) = result {
-                            debug!("[controller] Unable to notify the client {} for a response (client disconnected).", client);
-                        };
-                    },
-                    Err(error) => match error {
-                        TryRecvError::Empty => break,
-                        TryRecvError::Disconnected => panic!("Query channel disconnected."),
-                    },
-                }
-            }
-
-            // Put the thread asleep to run at a maximum of 128 time per second.
-            let now = Instant::now();
-            let elapsed_time = now.duration_since(previous_time);
-            match Duration::new(0, 1_000_000_000u32 / 128).checked_sub(elapsed_time) {
-                Some(sleep_time) => {
-                    thread::sleep(sleep_time);
-                },
-                None => {},
-            };
-        }
-    }).unwrap()
+        }).unwrap()
+    }
 }

--- a/src/database/storage/mod.rs
+++ b/src/database/storage/mod.rs
@@ -3,7 +3,6 @@ mod rule;
 mod persistence;
 
 use chrono::{DateTime, offset::Utc};
-use log::{debug, error};
 use self::job::{Storage as JobStorage};
 use self::persistence::{Entry, Job as PersistentJob, JobStatus as PersistentJobStatus, Rule as PersistentRule, Runner as PersistentRunner, Storage as PersistentStorage};
 use std::collections::HashMap;
@@ -44,14 +43,14 @@ impl Storage {
     /// Initialize this storage with data from the persistent storage. It returns all jobs that are
     /// in the `triggered` state (which is an temporary state, and thus should be resumed).
     pub fn initialize(&mut self) -> InitializeResult {
-        debug!("Initialization started with persisted data.");
+        log::debug!("Initialization started with persisted data.");
 
         let entries = match self.persistent_storage.initialize() {
             Ok(entries) => entries,
             Err(_) => return Err(InitializeError::UninitializablePersistentStorage),
         };
 
-        debug!("Reconstructing the in-memory storage from all {:?} persisted entries.", entries.len());
+        log::debug!("Reconstructing the in-memory storage from all {:?} persisted entries.", entries.len());
         let mut triggered = Vec::new();
         for entry in entries {
             match entry {
@@ -69,7 +68,7 @@ impl Storage {
             };
         };
 
-        debug!("Initialization properly done with persisted data.");
+        log::info!("Initialization properly done with persisted data.");
 
         Ok(triggered)
     }
@@ -94,7 +93,7 @@ impl Storage {
                 Ok(())
             },
             Err(_) => {
-                error!("Unable to persist the job {:?} to the storage.", &job);
+                log::error!("Unable to persist the job {:?} to the storage.", &job);
 
                 Err(WriteError::PersistenceFailure)
             },
@@ -111,7 +110,7 @@ impl Storage {
                 Ok(())
             },
             Err(_) => {
-                error!("Unable to persist the rule {:?} to the storage.", &rule);
+                log::error!("Unable to persist the rule {:?} to the storage.", &rule);
 
                 Err(WriteError::PersistenceFailure)
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use crossbeam_channel::select;
 use crossbeam_channel::unbounded;
 use self::configuration::Configuration;
 use self::configuration::LogLevel as ConfigurationLogLevel;
+use self::controller::Controller;
 use self::database::Database;
 use self::database::execution::protocol::Request as DatabaseExecutionRequest;
 use self::database::execution::protocol::Response as DatabaseExecutionResponse;
@@ -52,7 +53,7 @@ fn main() {
     let (processor_execution_response_sender, execution_response_receiver) = unbounded();
 
     // Spawn the controller, the database and the processor.
-    controller::start(query_owning_side);
+    Controller::start(configuration.controller.listen.to_string(), query_owning_side);
     Database::start(query_reverse_side, (database_execution_request_sender, database_execution_response_receiver));
     Processor::start((processor_execution_response_sender, processor_execution_request_receiver));
 


### PR DESCRIPTION
It creates the option `controller.listen`, taking any String, and configuring the controller's listen address. By default, its value is `127.0.0.1:5678`, allowing only localhost clients to connect through the port `5678`.

It can be configured to any value describing a standard listen address. Configured with the value `0.0.0.0:5678`, it will accept connections from any client on the port `5678`. The port can also be set to `127.0.0.1:0` to request that the OS assigns a port to the listener (although currently, the assigned port is only retrievable from `info` logs in a human readable format).

Entering an unlistenable value (an invalid address format, a port already in use, etc.) will cause the component to panic, making Kairoi stops with an error.