### PR TITLE
WIP: Feature / Database Storage Persistence

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -57,6 +57,7 @@ pub struct Controller {
 #[derive(Debug, Deserialize, Validate)]
 #[serde(deny_unknown_fields)]
 pub struct Database {
+    pub persistence: bool,
     pub fsync_on_persist: bool,
     #[validate(range(min = 1, max = 65535))]
     pub framerate: i64,
@@ -64,6 +65,7 @@ pub struct Database {
 impl Default for Database {
     fn default() -> Self {
         Self {
+            persistence: true,
             fsync_on_persist: true,
             framerate: 512,
         }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -38,6 +38,7 @@ pub struct Database {
 pub type ExecutionSender = UnderlyingExecutionSender;
 pub type ExecutionReceiver = UnderlyingExecutionReceiver;
 pub struct Configuration {
+    pub persistence: bool,
     pub storage_persistence_fsync_on_persist: bool,
     pub framerate: u16,
 }
@@ -52,6 +53,7 @@ impl Database {
         thread::Builder::new().name("kairoi/db".to_string()).spawn(move || {
             let mut database = Database {
                 storage: Storage::new(StorageConfiguration {
+                    persistence: configuration.persistence,
                     persistence_fsync_on_persist: configuration.storage_persistence_fsync_on_persist,
                 }),
                 execution_client: ExecutionClient::new(execution_link),

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,7 @@ fn main() {
         query_reverse_side,
         (database_execution_request_sender, database_execution_response_receiver),
         DatabaseConfiguration {
+            persistence: configuration.database.persistence,
             storage_persistence_fsync_on_persist: configuration.database.fsync_on_persist,
             framerate: configuration.database.framerate as u16,
         },


### PR DESCRIPTION
It implements a new configuration option `database.persistence` that can completely disable the persistence of the database storage.

In theory, when disabled, it should greatly improve write performances for massive requests. In practice, it actually does have the same performances as when running with the existing `fsync_on_persist` option disabled (tested with batches of 1000 job write requests from a client).

This PR is not acceptable as it is right now, and we should go deeper on this path to find improvements.