### PR TITLE
Feature / Documentation Guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Kairoi is a **Time-based Job Scheduler**. It works as a server allowing its clients to schedule jobs to be executed in the future, using a simple text protocol (read more about the protocol in the [Kairoi Client Protocol documentation](docs/client-protocol.md)).
 
-Once the job execution time is past, Kairoi automatically triggers a job execution on a matching configured runner (read more about runners in the [Kairoi Runners documentation](docs/runners.md)).
+Once the job execution time is past, Kairoi automatically triggers a job execution on a matching configured runner (read more about runners in the [Kairoi Runners documentation](runners.md)). In its default configuration, Kairoi guarantees [ACID](https://en.wikipedia.org/wiki/ACID) properties on its transactions. Kairoi also uses a _at-least once_ delivery model: each job is guaranteed to be processed at-least once at some point after its execution date, but can also be processed more than one time. Thus, domain code handling jobs should be [idempotent](https://en.wikipedia.org/wiki/Idempotence).
 
 Kairoi currently targets running on Linux operating systems.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,12 @@ This file is the root of the Kairoi Official Documentation.
 
 Kairoi is a **Time-based Job Scheduler**. It works as a server allowing its clients to schedule jobs to be executed in the future, using a simple text protocol (read more about the protocol in the [Kairoi Client Protocol documentation](client-protocol.md)).
 
-Once the job execution time is past, Kairoi automatically triggers a job execution on a matching configured runner (read more about runners in the [Kairoi Runners documentation](runners.md)).
+Once the job execution time is past, Kairoi automatically triggers a job execution on a matching configured runner (read more about runners in the [Kairoi Runners documentation](runners.md)). In its default configuration, Kairoi guarantees [ACID](https://en.wikipedia.org/wiki/ACID) properties on its transactions. Kairoi also uses a _at-least once_ delivery model: each job is guaranteed to be processed at-least once, at some point after its execution date, but can also be processed more than one time. Thus, domain code handling jobs should be [idempotent](https://en.wikipedia.org/wiki/Idempotence).
 
 ### Summary
 
 - [Kairoi Client Protocol Documentation](client-protocol.md)
+- [Kairoi Instructions Reference](instructions.md)
 - [Kairoi Runners Documentation](runners.md)
 - [Kairoi Server Configuration Reference](configuration.md)
 


### PR DESCRIPTION
Since Kairoi uses very specific and opinionated models, it should be made clear to users what it can imply. In particular, the at-least once delivery model impacts the code that developers should build when using Kairoi, and should be disclaimed early in the documentation resources.

It describes more precisely, in the Quick Words of the main README and the documentation index, the ACID constraints that Kairoi is trying to implement for its transactions, and the "at-least once" delivery model that Kairoi is using for job processing.