### PR TITLE
Feature / Rust Upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/emerick42/kairoi"
 license = "MIT"
 publish = false
+rust-version = "1.57.0"
 
 [features]
 default = ["runner-shell", "runner-amqp"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Kairoi currently targets running on Linux operating systems.
 
 ## Development
 
-Developping on Kairoi requires you to have [Rust installed on your machine](https://www.rust-lang.org/tools/install) in its latest version (`1.54.0` as of today).
+Developping on Kairoi requires you to have [Rust installed on your machine](https://www.rust-lang.org/tools/install).
 
 ### Installation
 

--- a/src/controller/client/mod.rs
+++ b/src/controller/client/mod.rs
@@ -69,14 +69,14 @@ impl Client {
                         let buffer = match bytes_to_parse {
                             Some(bytes_to_parse) => {
                                 let mut copied_buffer = vec![0; bytes_to_parse.len() + length];
-                                &copied_buffer[0..bytes_to_parse.len()].copy_from_slice(&bytes_to_parse);
-                                &copied_buffer[bytes_to_parse.len()..bytes_to_parse.len() + length].copy_from_slice(&buffer[0..length]);
+                                copied_buffer[0..bytes_to_parse.len()].copy_from_slice(&bytes_to_parse);
+                                copied_buffer[bytes_to_parse.len()..bytes_to_parse.len() + length].copy_from_slice(&buffer[0..length]);
 
                                 copied_buffer
                             },
                             None => {
                                 let mut copied_buffer = vec![0; length];
-                                &copied_buffer[..].copy_from_slice(&buffer[..length]);
+                                copied_buffer[..].copy_from_slice(&buffer[..length]);
 
                                 copied_buffer
                             },

--- a/src/database/storage/persistence/encoder.rs
+++ b/src/database/storage/persistence/encoder.rs
@@ -159,9 +159,9 @@ impl Encoder {
 
         let mut result = vec![0; 12 + identifier_size as usize];
         result[0] = 0;
-        &result[1..3].copy_from_slice(&identifier_size.to_be_bytes());
-        &result[3..(3 + identifier_size as usize)].copy_from_slice(job.identifier.as_bytes());
-        &result[(3 + identifier_size as usize)..(11 + identifier_size as usize)].copy_from_slice(&job.execution.timestamp_nanos().to_be_bytes());
+        result[1..3].copy_from_slice(&identifier_size.to_be_bytes());
+        result[3..(3 + identifier_size as usize)].copy_from_slice(job.identifier.as_bytes());
+        result[(3 + identifier_size as usize)..(11 + identifier_size as usize)].copy_from_slice(&job.execution.timestamp_nanos().to_be_bytes());
         result[11 + identifier_size as usize] = match job.status {
             JobStatus::Planned => 0,
             JobStatus::Triggered => 1,
@@ -209,12 +209,12 @@ impl Encoder {
                 };
                 let mut result = vec![0; 7 + dsn_size as usize + exchange_size as usize + routing_key_size as usize];
                 result[0] = 1;
-                &result[1..3].copy_from_slice(&dsn_size.to_be_bytes());
-                &result[3..(3 + dsn_size as usize)].copy_from_slice(dsn.as_bytes());
-                &result[(3 + dsn_size as usize)..(5 + dsn_size as usize)].copy_from_slice(&exchange_size.to_be_bytes());
-                &result[(5 + dsn_size as usize)..(5 + dsn_size as usize + exchange_size as usize)].copy_from_slice(exchange.as_bytes());
-                &result[(5 + dsn_size as usize + exchange_size as usize)..(7 + dsn_size as usize + exchange_size as usize)].copy_from_slice(&routing_key_size.to_be_bytes());
-                &result[(7 + dsn_size as usize + exchange_size as usize)..].copy_from_slice(routing_key.as_bytes());
+                result[1..3].copy_from_slice(&dsn_size.to_be_bytes());
+                result[3..(3 + dsn_size as usize)].copy_from_slice(dsn.as_bytes());
+                result[(3 + dsn_size as usize)..(5 + dsn_size as usize)].copy_from_slice(&exchange_size.to_be_bytes());
+                result[(5 + dsn_size as usize)..(5 + dsn_size as usize + exchange_size as usize)].copy_from_slice(exchange.as_bytes());
+                result[(5 + dsn_size as usize + exchange_size as usize)..(7 + dsn_size as usize + exchange_size as usize)].copy_from_slice(&routing_key_size.to_be_bytes());
+                result[(7 + dsn_size as usize + exchange_size as usize)..].copy_from_slice(routing_key.as_bytes());
 
                 result
             },
@@ -225,8 +225,8 @@ impl Encoder {
                 };
                 let mut result = vec![0; 3 + command_size as usize];
                 result[0] = 0;
-                &result[1..3].copy_from_slice(&command_size.to_be_bytes());
-                &result[3..].copy_from_slice(command.as_bytes());
+                result[1..3].copy_from_slice(&command_size.to_be_bytes());
+                result[3..].copy_from_slice(command.as_bytes());
 
                 result
             },
@@ -235,11 +235,11 @@ impl Encoder {
         // Encode the rule.
         let mut result = vec![0; 5 + identifier_size as usize + pattern_size as usize + encoded_runner.len()];
         result[0] = 1;
-        &result[1..3].copy_from_slice(&identifier_size.to_be_bytes());
-        &result[3..(3 + identifier_size as usize)].copy_from_slice(rule.identifier.as_bytes());
-        &result[(3 + identifier_size as usize)..(5 + identifier_size as usize)].copy_from_slice(&pattern_size.to_be_bytes());
-        &result[(5 + identifier_size as usize)..(5 + identifier_size as usize + pattern_size as usize)].copy_from_slice(rule.pattern.as_bytes());
-        &result[(5 + identifier_size as usize + pattern_size as usize)..].copy_from_slice(&encoded_runner);
+        result[1..3].copy_from_slice(&identifier_size.to_be_bytes());
+        result[3..(3 + identifier_size as usize)].copy_from_slice(rule.identifier.as_bytes());
+        result[(3 + identifier_size as usize)..(5 + identifier_size as usize)].copy_from_slice(&pattern_size.to_be_bytes());
+        result[(5 + identifier_size as usize)..(5 + identifier_size as usize + pattern_size as usize)].copy_from_slice(rule.pattern.as_bytes());
+        result[(5 + identifier_size as usize + pattern_size as usize)..].copy_from_slice(&encoded_runner);
 
         Ok(result)
     }

--- a/src/database/storage/persistence/logfile/encoding.rs
+++ b/src/database/storage/persistence/logfile/encoding.rs
@@ -28,8 +28,8 @@ impl Encoder {
         match entry.len() <= u32::MAX as usize {
             true => {
                 let mut encoded = vec![0; 4 + entry.len()];
-                &encoded[0..4].copy_from_slice(&(entry.len() as u32).to_be_bytes());
-                &encoded[4..].copy_from_slice(entry);
+                encoded[0..4].copy_from_slice(&(entry.len() as u32).to_be_bytes());
+                encoded[4..].copy_from_slice(entry);
 
                 Ok(encoded)
             },


### PR DESCRIPTION
It upgrades the minimum Rust version used to compile Kairoi to the current Rust version. Additionnally, we start using the `rust-version` parameter in the `Cargo.toml` package file to programmatically prevent build using unsupported Rust versions.

Finally, it fixes warnings generated by usages of the `copy_from_slice` function from the standard library.