### PR TITLE
Feature / Configuration File Path Compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## Unreleased
 
+- Allow the default configuration file's path to be configured at compilation time - [#28](https://github.com/emerick42/kairoi/pull/28)
 - Create a changelog file at the root of the project - [#27](https://github.com/emerick42/kairoi/pull/27)
 - Upgrade the minimum Rust version used to compile Kairoi to the current Rust version - [#26](https://github.com/emerick42/kairoi/pull/26)

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -1,0 +1,26 @@
+# Kairoi Compilation
+
+## Quick Words
+
+The first step before being able to use Kairoi is to compile it. The compilation process is made to be simple to use. The program can be compiled (providing default features) by cloning the repository and running `cargo build --release`. The executable can then be found at `target/release/kairoi`.
+
+However, to provide useful features for Kairoi administrators, there may be times where advanced compilation can be used. The main way to customize Kairoi's compilation is by providing environment variables to the build command. For example, the default configuration file's path can be set using `CONFIGURATION_PATH="/etc/kairoi/configuration.toml" cargo build --release`. This will read the configuration from the file `/etc/kairoi/configuration.toml` instead of the default `./configuration.toml` that is relative to the launch directory.
+
+## Usage
+
+### Configuration Path
+
+`CONFIGURATION_PATH` (default: `configuration.toml`)
+
+This option sets the default configuration file's path used to read the configuration. It can receive either an absolute or a relative path. In case of a relative path, the path will be computed from the directory where the Kairoi server is launched.
+
+If the configuration file doesn't exist, the program will start with the default configuration without any warning (read the [Kairoi Configuration Reference](configuration.md) for more informations on default values). However, if the file has an invalid format, Kairoi won't start at all.
+
+```bash
+# This will read the configuration from /etc/kairoi/configuration.toml
+CONFIGURATION_PATH="/etc/kairoi/configuration.toml" cargo build --release && ./target/release/kairoi
+# This will read the configuration from ./vars/configuration.toml
+CONFIGURATION_PATH="vars/configuration.toml" cargo build --release && ./target/release/kairoi
+```
+
+## Internals

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 ## Quick Words
 
-Kairoi servers can be configured at runtime using a [TOML](https://toml.io/en/) configuration file. The configuration file must be located at `configuration.toml`, relative to the executable directory. Since every option has a default value, a Kairoi server can be started without any configuration file.
+Kairoi servers can be configured at runtime using a [TOML](https://toml.io/en/) configuration file. With the default compilation parameters (you can read more on compilation parameters in the [Kairoi Compilation documentation](compilation.md)), the configuration is read from  the file `configuration.toml`, relative to the executable directory. Since every option has a default value, a Kairoi server can be started without any configuration file.
 
 Here is an example of configuration file with all default options explicitly set:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Once the job execution time is past, Kairoi automatically triggers a job executi
 - [Kairoi Instructions Reference](instructions.md)
 - [Kairoi Runners Documentation](runners.md)
 - [Kairoi Server Configuration Reference](configuration.md)
+- [Kairoi Compilation Documentation](compilation.md)
 
 ## Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use self::processor::protocol::Response as ProcessorExecutionResponse;
 use self::processor::protocol::Runner as ProcessorExecutionRunner;
 
 fn main() {
-    let configuration = match Configuration::new() {
+    let configuration = match Configuration::new(None) {
         Ok(configuration) => configuration,
         Err(message) => {
             Logger::initialize(LoggerLevel::Error);


### PR DESCRIPTION
This PR is a solution proposal for the issue https://github.com/emerick42/kairoi/issues/25.

It makes the default configuration file's path configurable using Rust compilation parameters. When passing the `CONFIGURATION_PATH` environment variable when building the server (for example using `CONFIGURATION_PATH="/etc/kairoi/configuration.toml" cargo build --release`), it will replace the default path (currently `configuration.toml`, a path relative to the launch directory) with the given value. The value can be an absolute or a relative path. In case of a relative path, it is computed from the directory where the executable is launched.

This solution has the main advantage to not add any complexity at execution time. It's also useful to configure the server following different Linux distributions recommendations.

However, this is still not a convenient way for users to configure their instances, since it requires recompiling the software. It can be used along other solutions that are users oriented.