### PR TITLE
Feature / Configuration File Path CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "textwrap",
+]
+
+[[package]]
 name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +524,7 @@ version = "0.1.0"
 dependencies = [
  "amiquip",
  "chrono",
+ "clap",
  "config",
  "crossbeam-channel 0.5.1",
  "log",
@@ -610,9 +624,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "minimal-lexical"
@@ -802,6 +816,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1206,6 +1229,12 @@ dependencies = [
  "remove_dir_all",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ config = { version = "0.11.0", default-features = false, features = ["toml"] }
 serde = { version = "~1.0.130", features = ["derive"] }
 serde_derive = { version = "~1.0.130" }
 validator = { version = "0.14.0", features = ["derive"] }
+clap = { version = "~3.0.0", default-features = false, features = ["std", "cargo"] }
 # Optional dependencies.
 amiquip = { version = "0.3.3", optional = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,48 @@
+//! Kairoi's CLI management, parsing CLI arguments given by the user.
+//!
+//! This module provides a complete handling on CLI arguments, including parsing arguments given by
+//! the user, but also displaying the help and version commands. When arguments cannot get parsed,
+//! it exits the program, displaying an appropriate message and returning the proper error code to
+//! the parent shell.
+//!
+//! Currently, there is a single argument handles by this module:
+//! * `-c`, `--config`: it takes a value as parameter, being the path to the configuration file
+//! used for the current execution.
+
+use clap::App;
+use clap::crate_name;
+use clap::crate_version;
+use clap::Arg;
+
+pub struct Arguments {
+    pub configuration_path: Option<String>,
+}
+
+pub struct Application {}
+
+impl Application {
+    /// Handle current CLI arguments. When arguments cannot get parsed, it exits the program,
+    /// displaying the corresponding message, and returning the proper error code.
+    pub fn handle_arguments() -> Arguments {
+        let matches = App::new(crate_name!())
+            .version(crate_version!())
+            .arg(
+                Arg::new("configuration_path")
+                    .short('c')
+                    .long("config")
+                    .takes_value(true)
+                    .value_name("FILE")
+                    .help("Sets the path of the configuration file")
+            )
+            .help_template("USAGE: {usage}\n\n{all-args}")
+            .get_matches()
+        ;
+
+        Arguments {
+            configuration_path: match matches.value_of("configuration_path") {
+                Some(path) => Some(path.to_string()),
+                None => None,
+            }
+        }
+    }
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -95,8 +95,8 @@ impl Configuration {
     /// The default path is set at compilation time, by using the CONFIGURATION_PATH environment
     /// variable. When this variable is not set, it defaults to `configuration.toml`, loading the
     /// file relatively to the executable launch.
-    pub fn new(path: Option<String>) -> Result<Self, String> {
-        match Self::load(path) {
+    pub fn new(configuration_path: Option<&str>) -> Result<Self, String> {
+        match Self::load(configuration_path) {
             Ok(configuration) => {
                 match configuration.validate() {
                     Ok(_) => {},
@@ -109,12 +109,12 @@ impl Configuration {
         }
     }
 
-    fn load(path: Option<String>) -> Result<Self, ConfigError> {
+    fn load(configuration_path: Option<&str>) -> Result<Self, ConfigError> {
         let mut configuration = Config::default();
 
         let file =
-            match path {
-                Some(path) => File::with_name(&path),
+            match configuration_path {
+                Some(path) => File::with_name(path),
                 None => match option_env!("CONFIGURATION_PATH") {
                     Some(path) => File::with_name(path),
                     None => File::with_name("configuration.toml"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 extern crate chrono;
+extern crate clap;
 extern crate config;
 extern crate crossbeam_channel;
 extern crate log;
@@ -8,6 +9,7 @@ extern crate serde;
 extern crate simple_logger;
 extern crate validator;
 
+mod cli;
 mod configuration;
 mod controller;
 mod database;
@@ -19,6 +21,7 @@ mod sync;
 
 use crossbeam_channel::select;
 use crossbeam_channel::unbounded;
+use self::cli::Application;
 use self::configuration::Configuration;
 use self::configuration::LogLevel as ConfigurationLogLevel;
 use self::controller::Controller;
@@ -35,7 +38,9 @@ use self::processor::protocol::Response as ProcessorExecutionResponse;
 use self::processor::protocol::Runner as ProcessorExecutionRunner;
 
 fn main() {
-    let configuration = match Configuration::new(None) {
+    let arguments = Application::handle_arguments();
+
+    let configuration = match Configuration::new(arguments.configuration_path.as_deref()) {
         Ok(configuration) => configuration,
         Err(message) => {
             Logger::initialize(LoggerLevel::Error);


### PR DESCRIPTION
This is a solution proposal for the issue https://github.com/emerick42/kairoi/issues/25.

It handles a `-c` (or `--config`) CLI argument setting the configuration file used for the current execution. It allows the user to specify a configuration file different from the one specified at compile time. For example, a user can launch `kairoi -c var/configuration.toml` to use a configuration file located at `./var/configuration.toml`, relative to the launch directory. An absolute path can also be passed: `kairoi --config=/etc/kairoi/configuration.toml`.

The implementation uses [clap](https://crates.io/crates/clap) to handle CLI arguments. While it can be limited in term of customization, it also provides useful features by default. A standard `--help` and `--version` options are provided, displaying informations on existing options.